### PR TITLE
add : prof/before and prof/after

### DIFF
--- a/audit/ProfApp/templates/ProfApp/class_management_after.html
+++ b/audit/ProfApp/templates/ProfApp/class_management_after.html
@@ -23,6 +23,8 @@
 
 	<link href="{% static 'ProfApp/css/app.css' %}" rel="stylesheet">
 	<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
+
+	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
 </head>
 
 <body>
@@ -98,7 +100,7 @@
 														</select>
 													</td>
 													<td class="text-center">
-														<button class="badge btn-primary btn-sm">학생관리</button>
+														<button data-bs-toggle="collapse" href="#test" aria-expanded="false" aria-controls="test" class="badge btn-primary btn-sm">학생관리</button>
 													</td>
 												</tr>
 												<tr>
@@ -140,7 +142,7 @@
 						</div>
 
 						<!-- 청강학생정보리스트입니다 -->
-						<div class="col-md-12 col-xl-12">
+						<div id="test" class="collapse col-md-12 col-xl-12">
 							<div class="card">
 								<div class="card-header">
 
@@ -168,7 +170,20 @@
 													<td class="text-center">000000</td>
 													<td class="text-center">06</td>
 													<td class="text-center">
-														<button class="badge btn-primary btn-sm">의견작성</button>
+														<button data-bs-toggle="collapse" href="#collapseExample" aria-expanded="false" aria-controls="collapseExample" class="badge btn-primary btn-sm">의견작성</button>
+													</td>
+												</tr>
+												<tr>
+													<td colspan="6" class="p-0">
+														<div class="collapse" id="collapseExample">
+															<div class="card">
+																<h5 class="card-title mt-3 mb-3">의견작성</h5>
+																<textarea class="form-control" placeholder="여기에 의견을 작성하세요" rows="5"></textarea>																
+															</div>
+															<div style="float:right">
+																<button class="btn btn-primary mt-0 mb-3 mr-10">경고/의견보내기</button>
+															</div>
+														</div>
 													</td>
 												</tr>
 												<tr>
@@ -178,7 +193,20 @@
 													<td class="text-center">000000</td>
 													<td class="text-center">06</td>
 													<td class="text-center">
-														<button class="badge btn-primary btn-sm">의견작성</button>
+														<button data-bs-toggle="collapse" href="#collapseExample2" aria-expanded="false" aria-controls="collapseExample2" class="badge btn-primary btn-sm">의견작성</button>
+													</td>
+												</tr>
+												<tr>
+													<td colspan="6" class="p-0">
+														<div class="collapse" id="collapseExample2">
+															<div class="card">
+																<h5 class="card-title mt-3 mb-3">의견작성</h5>
+																<textarea class="form-control" placeholder="여기에 의견을 작성하세요" rows="5"></textarea>																
+															</div>
+															<div style="float:right">
+																<button class="btn btn-primary mt-0 mb-3 mr-10">경고/의견보내기</button>
+															</div>
+														</div>
 													</td>
 												</tr>
 												<tr>
@@ -188,7 +216,20 @@
 													<td class="text-center">000000</td>
 													<td class="text-center">06</td>
 													<td class="text-center">
-														<button class="badge btn-primary btn-sm">의견작성</button>
+														<button data-bs-toggle="collapse" href="#collapseExample3" aria-expanded="false" aria-controls="collapseExample3" class="badge btn-primary btn-sm">의견작성</button>
+													</td>
+												</tr>
+												<tr>
+													<td colspan="6" class="p-0">
+														<div class="collapse" id="collapseExample3">
+															<div class="card">
+																<h5 class="card-title mt-3 mb-3">의견작성</h5>
+																<textarea class="form-control" placeholder="여기에 의견을 작성하세요" rows="5"></textarea>																
+															</div>
+															<div style="float:right">
+																<button class="btn btn-primary mt-0 mb-3 mr-10">경고/의견보내기</button>
+															</div>
+														</div>
 													</td>
 												</tr>
 												<tr>
@@ -198,7 +239,20 @@
 													<td class="text-center">000000</td>
 													<td class="text-center">06</td>
 													<td class="text-center">
-														<button class="badge btn-primary btn-sm">의견작성</button>
+														<button data-bs-toggle="collapse" href="#collapseExample4" aria-expanded="false" aria-controls="collapseExample4" class="badge btn-primary btn-sm">의견작성</button>
+													</td>
+												</tr>
+												<tr>
+													<td colspan="6" class="p-0">
+														<div class="collapse" id="collapseExample4">
+															<div class="card">
+																<h5 class="card-title mt-3 mb-3">의견작성</h5>
+																<textarea class="form-control" placeholder="여기에 의견을 작성하세요" rows="5"></textarea>																
+															</div>
+															<div style="float:right">
+																<button class="btn btn-primary mt-0 mb-3 mr-10">경고/의견보내기</button>
+															</div>
+														</div>
 													</td>
 												</tr>
 												<tr>
@@ -208,7 +262,20 @@
 													<td class="text-center">000000</td>
 													<td class="text-center">06</td>
 													<td class="text-center">
-														<button class="badge btn-primary btn-sm">의견작성</button>
+														<button data-bs-toggle="collapse" href="#collapseExample5" aria-expanded="false" aria-controls="collapseExample5" class="badge btn-primary btn-sm">의견작성</button>
+													</td>
+												</tr>
+												<tr>
+													<td colspan="6" class="p-0">
+														<div class="collapse" id="collapseExample5">
+															<div class="card">
+																<h5 class="card-title mt-3 mb-3">의견작성</h5>
+																<textarea class="form-control" placeholder="여기에 의견을 작성하세요" rows="5"></textarea>																
+															</div>
+															<div style="float:right">
+																<button class="btn btn-primary mt-0 mb-3 mr-10">경고/의견보내기</button>
+															</div>
+														</div>
 													</td>
 												</tr>
 											</tbody>

--- a/audit/ProfApp/templates/ProfApp/class_management_before.html
+++ b/audit/ProfApp/templates/ProfApp/class_management_before.html
@@ -22,6 +22,7 @@
 
 	<link href="{% static 'ProfApp/css/app.css' %}" rel="stylesheet">
 	<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
+	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
 </head>
 
 <body>
@@ -97,7 +98,7 @@
 														</select>
 													</td>
 													<td class="text-center">
-														<button class="badge btn-primary btn-sm">학생관리</button>
+														<button data-bs-toggle="collapse" href="#test" aria-expanded="false" aria-controls="test" class="badge btn-primary btn-sm">학생관리</button>
 													</td>
 												</tr>
 												<tr>
@@ -139,7 +140,7 @@
 						</div>
 
 						<!-- 청강학생정보리스트입니다 -->
-						<div class="col-md-12 col-xl-12">
+						<div id="test" class="collapse col-md-12 col-xl-12">
 							<div class="card">
 								<div class="card-header">
 
@@ -167,7 +168,7 @@
 													<td class="text-center">000000</td>
 													<td class="text-center">06</td>
 													<td class="text-center">
-														<button class="badge btn-primary btn-sm">의견작성</button>
+														<button class="btn btn-primary btn-sm disabled" aria-disabled="true">의견작성</button>
 													</td>
 												</tr>
 												<tr>
@@ -177,7 +178,7 @@
 													<td class="text-center">000000</td>
 													<td class="text-center">06</td>
 													<td class="text-center">
-														<button class="badge btn-primary btn-sm">의견작성</button>
+														<button class="btn btn-primary btn-sm disabled" aria-disabled="true">의견작성</button>
 													</td>
 												</tr>
 												<tr>
@@ -187,7 +188,7 @@
 													<td class="text-center">000000</td>
 													<td class="text-center">06</td>
 													<td class="text-center">
-														<button class="badge btn-primary btn-sm">의견작성</button>
+														<button class="btn btn-primary btn-sm disabled" aria-disabled="true">의견작성</button>
 													</td>
 												</tr>
 												<tr>
@@ -197,7 +198,7 @@
 													<td class="text-center">000000</td>
 													<td class="text-center">06</td>
 													<td class="text-center">
-														<button class="badge btn-primary btn-sm">의견작성</button>
+														<button class="btn btn-primary btn-sm disabled" aria-disabled="true">의견작성</button>
 													</td>
 												</tr>
 												<tr>
@@ -207,7 +208,7 @@
 													<td class="text-center">000000</td>
 													<td class="text-center">06</td>
 													<td class="text-center">
-														<button class="badge btn-primary btn-sm">의견작성</button>
+														<button class="btn btn-primary btn-sm disabled" aria-disabled="true">의견작성</button>
 													</td>
 												</tr>
 											</tbody>


### PR DESCRIPTION
prof/before 와 prof/after 페이지에서 유동적으로 나타나는 페이지 기능을 추가하였습니다.

1. prof/before , prof/after 페이지에서 '학생관리' 버튼을 누르면 아래에 청강 학생 정보 리스트가 뜨도록 수정
2. prof/before 페이지의 청강 학생 정보에서는 '의견 작성' 버튼이 비활성화되도록 수정
3. prof/after 페이지에서 '의견 작성' 버튼을 누르면 의견을 작성하고 보낼 수 있는 공간이 유동적으로 뜨도록 추가